### PR TITLE
docs: Bitbucket MCP local integration + wrapper scripts (closes #73)

### DIFF
--- a/scripts/mcp-bitbucket-wrapper.ps1
+++ b/scripts/mcp-bitbucket-wrapper.ps1
@@ -1,0 +1,65 @@
+<#!
+.SYNOPSIS
+  Bitbucket MCP Server Wrapper (Windows PowerShell)
+.DESCRIPTION
+  Securely launches the Bitbucket MCP server using a Generic Credential stored in Windows Credential Manager.
+  Only LOCAL MCP server usage is supported; Bitbucket does not have an official remote MCP server.
+
+  Create Generic Credential:
+    Control Panel > User Accounts > Credential Manager > Windows Credentials > Add a generic credential
+      Internet or network address: bitbucket-mcp
+      User name: app-password
+      Password: <your Bitbucket app password>
+
+  Or via PowerShell (run as current user):
+    cmd /c "cmdkey /add:bitbucket-mcp /user:app-password /pass:<your Bitbucket app password>"
+
+  NOTE: Set the Bitbucket username below (NOT an email address). Find it at:
+    https://bitbucket.org/account/settings/  ("Username" field in profile settings)
+
+.PARAMETER Args
+  Additional arguments passed through to the MCP server process.
+#>
+Param([Parameter(ValueFromRemainingArguments=$true)] [string[]]$Args)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Bitbucket username (NOT email) - CHANGE THIS
+$env:ATLASSIAN_BITBUCKET_USERNAME = '<username>'
+if ($env:ATLASSIAN_BITBUCKET_USERNAME -eq '<username>') {
+  Write-Error "Please edit ATLASSIAN_BITBUCKET_USERNAME in $(Split-Path -Leaf $PSCommandPath) before use."; exit 1
+}
+
+# Optional workspace override
+if (-not $env:BITBUCKET_DEFAULT_WORKSPACE) { $env:BITBUCKET_DEFAULT_WORKSPACE = 'Guttmacher' }
+
+function Get-AppPassword {
+  $target = 'bitbucket-mcp'
+  # Use cmdkey to enumerate, then parse. (CredentialManager module not strictly required.)
+  $listing = cmd /c "cmdkey /list" 2>$null
+  if (-not $listing -or $listing -notmatch $target) {
+    Write-Error "Credential '$target' not found. Create it in Windows Credential Manager (Generic Credentials)."; exit 1
+  }
+  # Need password retrieval; cmdkey cannot output password. Use CredentialManager module if available.
+  try {
+    if (-not (Get-Module -ListAvailable -Name CredentialManager)) { Import-Module CredentialManager -ErrorAction Stop }
+    $cred = Get-StoredCredential -Target $target
+    if (-not $cred) { throw "Stored credential not accessible via CredentialManager module" }
+    return $cred.Password
+  } catch {
+    Write-Error "Unable to read password for '$target'. Install CredentialManager module: Install-Module CredentialManager -Scope CurrentUser"; exit 1
+  }
+}
+
+if (-not $env:ATLASSIAN_BITBUCKET_APP_PASSWORD -or [string]::IsNullOrWhiteSpace($env:ATLASSIAN_BITBUCKET_APP_PASSWORD)) {
+  $env:ATLASSIAN_BITBUCKET_APP_PASSWORD = Get-AppPassword
+}
+
+# Launch via npx (ensures latest published version unless cached)
+# Consider pinning a version in highly controlled environments.
+$command = 'npx'
+$fullArgs = @('-y', '@aashari/mcp-server-atlassian-bitbucket') + $Args
+
+# Exec equivalent in PowerShell
+& $command @fullArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/mcp-bitbucket-wrapper.sh
+++ b/scripts/mcp-bitbucket-wrapper.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Bitbucket MCP Server Wrapper (macOS / Linux)
+# Securely launches the Bitbucket MCP server with credentials from macOS Keychain (macOS) or environment variables (fallback)
+#
+# Recommended: store ONLY the app password in Keychain; username is not secret.
+# Keychain setup (macOS):
+#   security add-generic-password -s "bitbucket-mcp" -a "app-password" -w "<app_password>"
+#   (Or use Keychain Access GUI: New Password Item... Name: bitbucket-mcp, Account: app-password, Password: <app_password>)
+# Usage:
+#   1. Edit ATLASSIAN_BITBUCKET_USERNAME below to your Bitbucket username (NOT your email address!)
+#   2. Ensure keychain item exists (see above) OR export ATLASSIAN_BITBUCKET_APP_PASSWORD before running.
+#   3. Run: ./mcp-bitbucket-wrapper.sh [args]
+#
+# Environment overrides (optional):
+#   BITBUCKET_DEFAULT_WORKSPACE (default: Guttmacher)
+#
+set -euo pipefail
+
+SERVICE_NAME="bitbucket-mcp"
+ACCOUNT_NAME="app-password"
+
+get_keychain_password() {
+  security find-generic-password -s "$SERVICE_NAME" -a "$ACCOUNT_NAME" -w 2>/dev/null || return 1
+}
+
+ATLASSIAN_BITBUCKET_USERNAME="<username>"  # <-- CHANGE THIS
+if [[ "$ATLASSIAN_BITBUCKET_USERNAME" == "<username>" ]]; then
+  echo "Error: Please edit ATLASSIAN_BITBUCKET_USERNAME in $(basename "$0") before use." >&2
+  exit 1
+fi
+
+if [[ -n "${ATLASSIAN_BITBUCKET_APP_PASSWORD:-}" ]]; then
+  APP_PASS="$ATLASSIAN_BITBUCKET_APP_PASSWORD"
+else
+  if APP_PASS=$(get_keychain_password); then
+    :
+  else
+    echo "Error: Could not retrieve Bitbucket app password from Keychain (service '$SERVICE_NAME', account '$ACCOUNT_NAME')." >&2
+    echo "Add it with: security add-generic-password -s '$SERVICE_NAME' -a '$ACCOUNT_NAME' -w '<app_password>'" >&2
+    exit 1
+  fi
+fi
+
+export ATLASSIAN_BITBUCKET_USERNAME
+export ATLASSIAN_BITBUCKET_APP_PASSWORD="$APP_PASS"
+export BITBUCKET_DEFAULT_WORKSPACE="${BITBUCKET_DEFAULT_WORKSPACE:-Guttmacher}"
+
+exec npx -y @aashari/mcp-server-atlassian-bitbucket "$@"


### PR DESCRIPTION
Adds Bitbucket MCP integration documentation and wrapper scripts.

Changes:
- README: New section "Bitbucket MCP (Local Only / Unofficial)" with macOS + Windows setup, security notes, troubleshooting, and minimal manual launch example.
- Added scripts:
  - scripts/mcp-bitbucket-wrapper.sh (macOS/Linux Keychain-based)
  - scripts/mcp-bitbucket-wrapper.ps1 (Windows Credential Manager-based)

Closes #73.

Validation:
- Followed existing style conventions.
- Added no external dependencies.
- Scripts are standalone; user must edit username placeholder.

Let me know if you want the section moved elsewhere or condensed.