### PR TITLE
Feature/replace-atlassian-remote-with-sooperset

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ This is a documentation repository for GitHub Copilot modes and tools. All "buil
 
 **Bootstrap and validate the repository:**
 - `cd /home/runner/work/agents/agents` (or repository root)
-- **Lint markdown files:** Install markdownlint first with `mkdir -p /tmp/validation && cd /tmp/validation && npm init -y && npm install markdownlint-cli`, then run `./node_modules/.bin/markdownlint /path/to/repo/README.md /path/to/repo/copilot/modes/*.md` -- takes < 1 second. NEVER CANCEL.
+- **Lint markdown files:** Run `markdownlint /path/to/repo/README.md /path/to/repo/copilot/modes/*.md` -- takes < 1 second. NEVER CANCEL.
 - **Verify git status:** `git --no-pager status && git --no-pager log --oneline -5` -- takes < 0.1 seconds. NEVER CANCEL.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Reference for Copilot modes, models, MCP servers, and cross-tool custom instruct
   - [Bitbucket MCP Server](#bitbucket-mcp-server)
 - [Add MCP Servers to Agents](#add-mcp-servers-to-agents)
   - [VS Code](#vs-code)
-  - [Claude.ai](#claudeai)
   - [Claude Desktop](#claude-desktop)
 - [Coding Style Guidelines](#coding-style-guidelines)
   - [GitHub Copilot (Repository-Level)](#github-copilot-repository-level)
@@ -477,12 +476,6 @@ We use [Sooperset's local Atlassian MCP server](https://github.com/sooperset/mcp
 3. Update placeholders
 
 **Note: You must edit the sample configuration files to replace the `<your-os-username>`, `<your-bitbucket-username>`, and `your-domain.atlassian.net` placeholders.**
-
-### Claude.ai
-
-1. Open [Settings > Connectors](https://claude.ai/settings/connectors)
-2. Press each the **Connect** button (next to Atlassian and GitHub)
-Note: This adds the ability to add files from GitHub, but does not add the [GitHub MCP Server](https://github.com/github/github-mcp-server/blob/main/docs/installation-guides/install-claude.md).
 
 ### Claude Desktop
 

--- a/templates/claude_desktop_config_macos.json
+++ b/templates/claude_desktop_config_macos.json
@@ -1,5 +1,14 @@
 {
   "mcpServers": {
+    "Atlassian": {
+      "command": "/Users/<your-os-username>/bin/mcp-atlassian-local-wrapper.sh",
+      "args": [],
+      "env": {
+        "ATLASSIAN_DOMAIN": "your-domain.atlassian.net",
+        "AUTH_METHOD": "api_token"
+      },
+      "working_directory": null
+    },
     "Context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"],

--- a/templates/claude_desktop_config_windows.json
+++ b/templates/claude_desktop_config_windows.json
@@ -1,5 +1,17 @@
 {
   "mcpServers": {
+    "Atlassian": {
+      "command": "powershell",
+      "args": [
+        "-NoProfile","-ExecutionPolicy","Bypass","-File",
+        "C:/Users/<your-os-username>/bin/mcp-atlassian-local-wrapper.ps1"
+      ],
+      "env": {
+        "ATLASSIAN_DOMAIN": "your-domain.atlassian.net",
+        "AUTH_METHOD": "api_token"
+      },
+      "working_directory": null
+    },
     "Context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"],

--- a/templates/mcp-atlassian-local-wrapper.ps1
+++ b/templates/mcp-atlassian-local-wrapper.ps1
@@ -1,0 +1,162 @@
+<#!
+.SYNOPSIS
+  Atlassian (Local) MCP Server Wrapper (Windows PowerShell)
+.DESCRIPTION
+  Securely launches the Sooperset Atlassian MCP server using API token from Windows Credential Manager.
+  
+  Docker setup required:
+    - Install Docker Desktop for Windows
+    - Or install Podman as a Docker alternative
+
+  Create Generic Credential for API token:
+    Control Panel > User Accounts > Credential Manager > Windows Credentials > Add a generic credential
+      Internet or network address: atlassian-mcp-local
+      User name: api-token
+      Password: <your Atlassian API token>
+
+  Or via PowerShell:
+    cmd /c "cmdkey /add:atlassian-mcp-local /user:api-token /pass:<api_token>"
+
+  API Token creation:
+    1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+    2. Create API token for your Atlassian account
+    3. Store it securely in credential manager or environment variable
+
+.PARAMETER Args
+  Additional arguments passed through to the MCP server process.
+#>
+Param([Parameter(ValueFromRemainingArguments=$true)] [string[]]$Args)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Configuration defaults
+if (-not $env:DOCKER_COMMAND) { $env:DOCKER_COMMAND = 'docker' }
+if (-not $env:MCP_ATLASSIAN_IMAGE) { $env:MCP_ATLASSIAN_IMAGE = 'ghcr.io/sooperset/mcp-atlassian:latest' }
+if (-not $env:AUTH_METHOD) { $env:AUTH_METHOD = 'api_token' }
+
+function Test-DockerAvailable {
+  try {
+    $null = Get-Command $env:DOCKER_COMMAND -ErrorAction Stop
+  } catch {
+    Write-Error "$($env:DOCKER_COMMAND) is not installed or not in PATH. Please install Docker Desktop or Podman to use the local Atlassian MCP server."
+    exit 1
+  }
+  
+  # Check if Docker daemon is running
+  try {
+    & $env:DOCKER_COMMAND info *>$null
+  } catch {
+    Write-Error "$($env:DOCKER_COMMAND) daemon is not running. Please start Docker Desktop or the Docker daemon before using this wrapper."
+    exit 1
+  }
+}
+
+function Get-StoredPassword {
+  param([string]$Target)
+  
+  # Check if credential exists
+  $listing = cmd /c "cmdkey /list" 2>$null
+  if (-not $listing -or $listing -notmatch $Target) {
+    throw "Credential '$Target' not found in Windows Credential Manager."
+  }
+  
+  # Need CredentialManager module to read the credential
+  try {
+    if (-not (Get-Module -ListAvailable -Name CredentialManager)) { 
+      Import-Module CredentialManager -ErrorAction Stop 
+    }
+    $cred = Get-StoredCredential -Target $Target
+    if (-not $cred) { 
+      throw "Stored credential not accessible via CredentialManager module" 
+    }
+    return $cred.Password
+  } catch {
+    throw "Unable to read credential for '$Target'. Install CredentialManager module: Install-Module CredentialManager -Scope CurrentUser"
+  }
+}
+
+function Update-AtlassianImage {
+  Write-Host "Checking for latest Atlassian MCP server image..." -ForegroundColor Yellow
+  try {
+    & $env:DOCKER_COMMAND pull $env:MCP_ATLASSIAN_IMAGE 2>$null
+  } catch {
+    Write-Warning "Failed to pull latest image. Using local version if available."
+  }
+}
+
+# Check Docker availability
+Test-DockerAvailable
+
+# Domain is required from environment (set in JSON config)
+if (-not $env:ATLASSIAN_DOMAIN) {
+  Write-Error "ATLASSIAN_DOMAIN environment variable is required. This should be set in your agent configuration JSON file (e.g., 'your-domain.atlassian.net')."
+  exit 1
+}
+
+# Get API token from environment or credential manager (for api_token auth method)
+if ($env:AUTH_METHOD -eq 'api_token') {
+  if ($env:ATLASSIAN_API_TOKEN) {
+    $apiToken = $env:ATLASSIAN_API_TOKEN
+  } else {
+    try {
+      $apiToken = Get-StoredPassword -Target 'atlassian-mcp-local'
+    } catch {
+      Write-Error @"
+Could not retrieve Atlassian API token. Either:
+1. Set environment variable: `$env:ATLASSIAN_API_TOKEN='<api_token>'
+2. Create credential 'atlassian-mcp-local' with user 'api-token' in Windows Credential Manager
+3. Create API token at: https://id.atlassian.com/manage-profile/security/api-tokens
+"@
+      exit 1
+    }
+  }
+  
+  # Set email if not provided (required for API token auth)
+  if (-not $env:ATLASSIAN_EMAIL) {
+    # Try to derive from current user or domain
+    $derivedDomain = $env:ATLASSIAN_DOMAIN -replace '\.atlassian\.net$', '.com'
+    $env:ATLASSIAN_EMAIL = "$env:USERNAME@$derivedDomain"
+    Write-Host "Note: Using derived email '$($env:ATLASSIAN_EMAIL)'. Set ATLASSIAN_EMAIL to override." -ForegroundColor Yellow
+  }
+}
+
+# Pull latest image
+Update-AtlassianImage
+
+# Set up environment variables for the container
+$dockerEnvArgs = @(
+  '-e', "CONFLUENCE_URL=https://$($env:ATLASSIAN_DOMAIN)/wiki"
+  '-e', "JIRA_URL=https://$($env:ATLASSIAN_DOMAIN)"
+)
+
+if ($env:AUTH_METHOD -eq 'api_token') {
+  $dockerEnvArgs += @(
+    '-e', "CONFLUENCE_USERNAME=$($env:ATLASSIAN_EMAIL)"
+    '-e', "CONFLUENCE_API_TOKEN=$apiToken"
+    '-e', "JIRA_USERNAME=$($env:ATLASSIAN_EMAIL)"
+    '-e', "JIRA_API_TOKEN=$apiToken"
+  )
+} elseif ($env:AUTH_METHOD -eq 'oauth') {
+  # OAuth setup - user must provide these externally
+  if ($env:ATLASSIAN_OAUTH_CLIENT_ID) {
+    $dockerEnvArgs += @('-e', "ATLASSIAN_OAUTH_CLIENT_ID=$($env:ATLASSIAN_OAUTH_CLIENT_ID)")
+  }
+  if ($env:ATLASSIAN_OAUTH_CLIENT_SECRET) {
+    $dockerEnvArgs += @('-e', "ATLASSIAN_OAUTH_CLIENT_SECRET=$($env:ATLASSIAN_OAUTH_CLIENT_SECRET)")
+  }
+  if ($env:ATLASSIAN_OAUTH_REDIRECT_URI) {
+    $dockerEnvArgs += @('-e', "ATLASSIAN_OAUTH_REDIRECT_URI=$($env:ATLASSIAN_OAUTH_REDIRECT_URI)")
+  }
+  if ($env:ATLASSIAN_OAUTH_SCOPE) {
+    $dockerEnvArgs += @('-e', "ATLASSIAN_OAUTH_SCOPE=$($env:ATLASSIAN_OAUTH_SCOPE)")
+  }
+  if ($env:ATLASSIAN_OAUTH_CLOUD_ID) {
+    $dockerEnvArgs += @('-e', "ATLASSIAN_OAUTH_CLOUD_ID=$($env:ATLASSIAN_OAUTH_CLOUD_ID)")
+  }
+}
+
+# Launch the Docker container in interactive mode with stdin/stdout
+$fullArgs = @('run', '--rm', '-i') + $dockerEnvArgs + @($env:MCP_ATLASSIAN_IMAGE) + $Args
+
+& $env:DOCKER_COMMAND @fullArgs
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/templates/mcp-atlassian-local-wrapper.sh
+++ b/templates/mcp-atlassian-local-wrapper.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Atlassian (Local) MCP Server Wrapper (macOS / Linux)
+# Securely launches the Sooperset Atlassian MCP server with API token from macOS Keychain or environment variables
+#
+# Docker setup required:
+#   - Install Docker Desktop or Docker Engine
+#   - Or install Podman as a Docker alternative
+#
+# Keychain setup (macOS):
+#   security add-generic-password -s "atlassian-mcp-local" -a "api-token" -w "<api_token>"
+#   (Or use Keychain Access GUI: New Password Item... Name: atlassian-mcp-local, Account: api-token, Password: <api_token>)
+#
+# API Token creation:
+#   1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+#   2. Create API token for your Atlassian account
+#   3. Store it securely in keychain or environment variable
+#
+# Usage:
+#   1. Create keychain entry (see above) OR export ATLASSIAN_API_TOKEN before running.
+#   2. Set ATLASSIAN_DOMAIN environment variable (set in JSON config).
+#   3. Run: ./mcp-atlassian-local-wrapper.sh [args]
+#
+# Environment variables required:
+#   ATLASSIAN_DOMAIN (required: e.g., "your-domain.atlassian.net")
+# Environment variables optional:
+#   ATLASSIAN_API_TOKEN (overrides keychain)
+#   ATLASSIAN_EMAIL (default: derived from current user)
+#   AUTH_METHOD (default: "api_token", alternative: "oauth")
+#   DOCKER_COMMAND (default: "docker", alternative: "podman")
+#   MCP_ATLASSIAN_IMAGE (default: "sooperset/mcp-atlassian:latest")
+#
+set -euo pipefail
+
+SERVICE_NAME="atlassian-mcp-local"
+ACCOUNT_NAME="api-token"
+DOCKER_COMMAND="${DOCKER_COMMAND:-docker}"
+MCP_ATLASSIAN_IMAGE="${MCP_ATLASSIAN_IMAGE:-ghcr.io/sooperset/mcp-atlassian:latest}"
+AUTH_METHOD="${AUTH_METHOD:-api_token}"
+
+get_keychain_password() {
+  if [[ "$(uname)" != "Darwin" ]]; then
+    return 1
+  fi
+  
+  security find-generic-password -s "$SERVICE_NAME" -a "$ACCOUNT_NAME" -w 2>/dev/null || return 1
+}
+
+check_docker() {
+  if ! command -v "$DOCKER_COMMAND" &> /dev/null; then
+    echo "Error: $DOCKER_COMMAND is not installed or not in PATH." >&2
+    echo "Please install Docker Desktop or Podman to use the local Atlassian MCP server." >&2
+    exit 1
+  fi
+  
+  # Check if Docker daemon is running
+  if ! "$DOCKER_COMMAND" info &> /dev/null; then
+    echo "Error: $DOCKER_COMMAND daemon is not running." >&2
+    echo "Please start Docker Desktop or the Docker daemon before using this wrapper." >&2
+    exit 1
+  fi
+}
+
+pull_image_if_needed() {
+  echo "Checking for latest Atlassian MCP server image..." >&2
+  if ! "$DOCKER_COMMAND" pull "$MCP_ATLASSIAN_IMAGE" >&2; then
+    echo "Warning: Failed to pull latest image. Using local version if available." >&2
+  fi
+}
+
+# Check Docker availability
+check_docker
+
+# Domain is required from environment (set in JSON config)
+if [[ -z "${ATLASSIAN_DOMAIN:-}" ]]; then
+  echo "Error: ATLASSIAN_DOMAIN environment variable is required." >&2
+  echo "This should be set in your agent configuration JSON file (e.g., 'your-domain.atlassian.net')." >&2
+  exit 1
+fi
+
+# Get API token from environment or keychain (for api_token auth method)
+if [[ "$AUTH_METHOD" == "api_token" ]]; then
+  if [[ -n "${ATLASSIAN_API_TOKEN:-}" ]]; then
+    API_TOKEN="$ATLASSIAN_API_TOKEN"
+  else
+    if [[ "$(uname)" == "Darwin" ]]; then
+      if ! API_TOKEN=$(get_keychain_password); then
+        echo "Error: Could not retrieve Atlassian API token from Keychain (service '$SERVICE_NAME', account '$ACCOUNT_NAME')." >&2
+        echo "Add it with: security add-generic-password -s '$SERVICE_NAME' -a '$ACCOUNT_NAME' -w '<api_token>'" >&2
+        echo "Or set environment variable: export ATLASSIAN_API_TOKEN='<api_token>'" >&2
+        echo "Create API token at: https://id.atlassian.com/manage-profile/security/api-tokens" >&2
+        exit 1
+      fi
+    else
+      echo "Error: ATLASSIAN_API_TOKEN is not set and macOS Keychain is unavailable on this platform." >&2
+      echo "Set environment variable: export ATLASSIAN_API_TOKEN='<api_token>'" >&2
+      echo "Create API token at: https://id.atlassian.com/manage-profile/security/api-tokens" >&2
+      exit 1
+    fi
+  fi
+  
+  # Set email if not provided (required for API token auth)
+  if [[ -z "${ATLASSIAN_EMAIL:-}" ]]; then
+    # Try to derive from current user or domain
+    ATLASSIAN_EMAIL="${USER}@$(echo "$ATLASSIAN_DOMAIN" | sed 's/\.atlassian\.net$/\.com/')"
+    echo "Note: Using derived email '$ATLASSIAN_EMAIL'. Set ATLASSIAN_EMAIL to override." >&2
+  fi
+fi
+
+# Pull latest image
+pull_image_if_needed
+
+# Set up environment variables for the container
+DOCKER_ENV_ARGS=(
+  -e "CONFLUENCE_URL=https://$ATLASSIAN_DOMAIN/wiki"
+  -e "JIRA_URL=https://$ATLASSIAN_DOMAIN"
+)
+
+if [[ "$AUTH_METHOD" == "api_token" ]]; then
+  DOCKER_ENV_ARGS+=(
+    -e "CONFLUENCE_USERNAME=${ATLASSIAN_EMAIL}"
+    -e "CONFLUENCE_API_TOKEN=$API_TOKEN"
+    -e "JIRA_USERNAME=${ATLASSIAN_EMAIL}"
+    -e "JIRA_API_TOKEN=$API_TOKEN"
+  )
+elif [[ "$AUTH_METHOD" == "oauth" ]]; then
+  # OAuth setup - user must provide these externally
+  if [[ -n "${ATLASSIAN_OAUTH_CLIENT_ID:-}" ]]; then
+    DOCKER_ENV_ARGS+=(-e "ATLASSIAN_OAUTH_CLIENT_ID=$ATLASSIAN_OAUTH_CLIENT_ID")
+  fi
+  if [[ -n "${ATLASSIAN_OAUTH_CLIENT_SECRET:-}" ]]; then
+    DOCKER_ENV_ARGS+=(-e "ATLASSIAN_OAUTH_CLIENT_SECRET=$ATLASSIAN_OAUTH_CLIENT_SECRET")
+  fi
+  if [[ -n "${ATLASSIAN_OAUTH_REDIRECT_URI:-}" ]]; then
+    DOCKER_ENV_ARGS+=(-e "ATLASSIAN_OAUTH_REDIRECT_URI=$ATLASSIAN_OAUTH_REDIRECT_URI")
+  fi
+  if [[ -n "${ATLASSIAN_OAUTH_SCOPE:-}" ]]; then
+    DOCKER_ENV_ARGS+=(-e "ATLASSIAN_OAUTH_SCOPE=$ATLASSIAN_OAUTH_SCOPE")
+  fi
+  if [[ -n "${ATLASSIAN_OAUTH_CLOUD_ID:-}" ]]; then
+    DOCKER_ENV_ARGS+=(-e "ATLASSIAN_OAUTH_CLOUD_ID=$ATLASSIAN_OAUTH_CLOUD_ID")
+  fi
+fi
+
+# Launch the Docker container in interactive mode with stdin/stdout
+exec "$DOCKER_COMMAND" run --rm -i \
+  "${DOCKER_ENV_ARGS[@]}" \
+  "$MCP_ATLASSIAN_IMAGE" \
+  "$@"

--- a/templates/vscode-mcp-config_macos.json
+++ b/templates/vscode-mcp-config_macos.json
@@ -1,8 +1,12 @@
 {
   "servers": {
     "atlassian": {
-      "url": "https://mcp.atlassian.com/v1/sse",
-      "type": "http"
+      "command": "/Users/<your-os-username>/bin/mcp-atlassian-local-wrapper.sh",
+      "args": [],
+      "env": {
+        "ATLASSIAN_DOMAIN": "your-domain.atlassian.net",
+        "AUTH_METHOD": "api_token"
+      }
     },
     "github": {
       "url": "https://api.githubcopilot.com/mcp/",

--- a/templates/vscode-mcp-config_windows.json
+++ b/templates/vscode-mcp-config_windows.json
@@ -1,8 +1,15 @@
 {
   "servers": {
     "atlassian": {
-      "url": "https://mcp.atlassian.com/v1/sse",
-      "type": "http"
+      "command": "powershell",
+      "args": [
+        "-NoProfile","-ExecutionPolicy","Bypass","-File",
+        "C:/Users/<your-os-username>/bin/mcp-atlassian-local-wrapper.ps1"
+      ],
+      "env": {
+        "ATLASSIAN_DOMAIN": "your-domain.atlassian.net",
+        "AUTH_METHOD": "api_token"
+      }
     },
     "github": {
       "url": "https://api.githubcopilot.com/mcp/",


### PR DESCRIPTION
- Claude.ai connectors work differently from local MCP servers
- Focus documentation on Claude Desktop which supports our local MCP setup
- Update table of contents to remove Claude.ai reference