### PR TITLE
jira and *confluence*, not bitbucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Model Context Provider (MCP) Servers provide a bridge between agents and APIs: A
 
 Local MCP servers run on your computer whereas remote MCP servers run in the cloud. 
  - Microsoft provides both kinds for GitHub. However, they describe their remote server as "[in preview](https://github.blog/changelog/2025-06-12-remote-github-mcp-server-is-now-available-in-public-preview/)".
- - Atlassian provides a remote server for Jira and Bitbucket. However, they describe it as "[in public beta](https://github.com/atlassian/atlassian-mcp-server)".
+ - Atlassian provides a remote server for Jira and Confluence. However, they describe it as "[in public beta](https://github.com/atlassian/atlassian-mcp-server)".
  - Atlassian subjects their beta to [usage limits](https://github.com/atlassian/atlassian-mcp-server?tab=readme-ov-file#beta-access-and-limits): 1,000 requests per hour per organization, plus unspecified per-user limits.
  - Occasionally, I have found Atlassian's server not to respond to requests.
 


### PR DESCRIPTION
said atlassian provided a remote mcp for jira and bitbucket when i meant and confluence
