### PR TITLE
feat: upload_keys.sh: upload keys from local to remote keychain

### DIFF
--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+# upload_keys.sh - Upload keychain credentials to remote SSH hosts
+# Extracts keys from local macOS keychain and uploads them to remote macOS hosts
+
+# Exit on any error (-e), treat unset variables as errors (-u), fail on pipe errors (-o pipefail)
+# This prevents the script from continuing if something goes wrong
+set -euo pipefail
+
+# ANSI color codes for terminal output (purely cosmetic, no security implications)
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # Reset to default color
+
+# Associative array mapping keychain locations to environment variable names
+# Format: "service_name:account_name"="ENV_VAR_NAME"
+# These define what keys to extract from macOS keychain and where to store them remotely
+declare -A KEYS=(
+    ["atlassian-mcp:domain"]="ATLASSIAN_DOMAIN"
+    ["atlassian-mcp:email"]="ATLASSIAN_EMAIL"
+    ["atlassian-mcp:token"]="ATLASSIAN_API_TOKEN"
+    ["bitbucket-mcp:username"]="ATLASSIAN_BITBUCKET_USERNAME"
+    ["bitbucket-mcp:app-password"]="ATLASSIAN_BITBUCKET_APP_PASSWORD"
+    ["github-mcp:token"]="GITHUB_PERSONAL_ACCESS_TOKEN"
+    ["api_keys:OPENAI_API_KEY"]="OPENAI_API_KEY"
+    ["api_keys:ANTHROPIC_API_KEY"]="ANTHROPIC_API_KEY"
+)
+
+# Global variables to track upload results and host/key lists
+# RESULTS: associative array storing outcome for each key+host combination
+# HOST_LIST: array of hosts we'll upload to
+# KEY_LIST: array of key definitions (currently unused but reserved)
+declare -A RESULTS
+declare -a HOST_LIST
+declare -a KEY_LIST
+
+# Extract a key from local macOS keychain
+# SECURITY NOTE: This only reads from local keychain, never writes secrets to files
+extract_key() {
+    local service_name="$1"  # Keychain service name (e.g., "github-mcp")
+    local account="$2"       # Account name within that service
+    local key
+    
+    # Use macOS security command to extract password (-w = password only, no metadata)
+    # 2>/dev/null suppresses error messages, || true prevents script exit on missing key
+    key=$(security find-generic-password -s "$service_name" -a "$account" -w 2>/dev/null || true)
+    if [[ -n "$key" ]]; then
+        echo "$key"  # Output the key value (will be captured by caller)
+        return 0     # Success
+    else
+        return 1     # Key not found
+    fi
+}
+
+# Discover SSH hosts that have ForwardAgent enabled
+# SECURITY NOTE: Only reads SSH config, doesn't modify anything
+get_ssh_hosts() {
+    local hosts=()  # Local array (not used in current implementation)
+    
+    # Check if SSH config file exists
+    if [[ ! -f ~/.ssh/config ]]; then
+        echo "Warning: ~/.ssh/config not found" >&2  # >&2 sends to stderr, not stdout
+        return 1
+    fi
+    
+    # Parse SSH config to find hosts with ForwardAgent enabled
+    # awk extracts host names (skipping wildcards like * or ?)
+    # sort -u removes duplicate entries
+    awk '/^Host / {for(i=2; i<=NF; i++) if($i !~ /[*?]/) print $i}' ~/.ssh/config | sort -u | while read -r host; do
+        # ssh -G shows the effective configuration for this host
+        # grep -q does a quiet search (no output, just exit code)
+        if [[ -n "$host" ]] && ssh -F ~/.ssh/config -G "$host" 2>/dev/null | grep -q "forwardagent yes"; then
+            echo "$host"  # Output qualifying host names
+        fi
+    done
+}
+
+# Show detected hosts to user and allow override
+# SECURITY NOTE: Only displays information and gets user input, no file operations
+confirm_hosts() {
+    local detected_hosts=("$@")  # "$@" expands to all function arguments as separate elements
+    
+    # Check if we found any hosts
+    if [[ ${#detected_hosts[@]} -eq 0 ]]; then  # ${#array[@]} gives array length
+        echo -e "${RED}No SSH hosts found with ForwardAgent enabled.${NC}"
+        exit 1
+    fi
+    
+    # Display the detected hosts
+    echo -e "${BLUE}Detected SSH hosts with ForwardAgent enabled:${NC}"
+    printf '  %s\n' "${detected_hosts[@]}"  # Print each host on its own line
+    echo
+    echo -e "${YELLOW}Press ENTER to use these hosts, or type custom host list (space-separated):${NC}"
+    read -r input  # -r prevents backslash escaping in user input
+    
+    # Use detected hosts if user just pressed Enter, otherwise parse custom input
+    if [[ -z "$input" ]]; then  # -z tests if string is empty
+        HOST_LIST=("${detected_hosts[@]}")  # Copy detected hosts to global array
+    else
+        # IFS temporarily changes field separator to space for word splitting
+        # read -ra splits input into array elements
+        IFS=' ' read -ra HOST_LIST <<< "$input"
+    fi
+    
+    echo -e "${GREEN}Using hosts:${NC}" "${HOST_LIST[@]}"
+    echo
+}
+
+# Upload all keys to a single remote host
+# SECURITY NOTE: Keys are passed as environment variables through SSH, never written to files
+upload_to_host() {
+    local host="$1"           # Target hostname
+    local env_vars=()         # Array to hold "VAR=value" pairs for SSH
+    local upload_script=""    # Bash script to execute on remote host
+    
+    echo -e "${BLUE}Processing host: $host${NC}"
+    
+    # Start building the script that will run on the remote host
+    upload_script="#!/bin/bash\nset -e\n\n"  # set -e makes remote script exit on errors
+    
+    # Process each key definition
+    for key_def in "${!KEYS[@]}"; do  # "${!KEYS[@]}" expands to all keys in associative array
+        # Split "service:account" into separate variables
+        # IFS=':' temporarily sets field separator to colon for this read command only
+        IFS=':' read -r service_name account <<< "$key_def"
+        local env_var="${KEYS[$key_def]}"  # Get the environment variable name
+        local key_value
+        
+        # Try to extract this key from local keychain
+        if key_value=$(extract_key "$service_name" "$account"); then
+            # Key found locally - add to environment variables for SSH
+            env_vars+=("${env_var}=${key_value}")
+            
+            # Add commands to remote script to handle this key
+            upload_script+="# Upload $env_var\n"
+            upload_script+="if [[ -n \"\${${env_var}:-}\" ]]; then\n"  # Check if env var is set
+            # Check if key already exists in remote keychain
+            upload_script+="  if security find-generic-password -s \"$service_name\" -a \"$account\" >/dev/null 2>&1; then\n"
+            upload_script+="    security delete-generic-password -s \"$service_name\" -a \"$account\" 2>/dev/null || true\n"
+            upload_script+="    echo \"r:${key_def}\"\n"  # Report "replaced"
+            upload_script+="  else\n"
+            upload_script+="    echo \"a:${key_def}\"\n"  # Report "added"
+            upload_script+="  fi\n"
+            # Add the new key to remote keychain (-U allows updates)
+            upload_script+="  security add-generic-password -s \"$service_name\" -a \"$account\" -w \"\${${env_var}}\" -U\n"
+            upload_script+="else\n"
+            upload_script+="  echo \"x:${key_def}:missing_env_var\"\n"  # Report error
+            upload_script+="fi\n\n"
+        else
+            # Key not found locally - mark as missing
+            RESULTS["${key_def}:${host}"]="missing"
+        fi
+    done
+    
+    # If no keys were found locally, skip this host
+    if [[ ${#env_vars[@]} -eq 0 ]]; then
+        echo -e "${RED}  No keys extracted for $host${NC}"
+        return 1
+    fi
+    
+    # Execute the script on remote host
+    # printf '%b' interprets backslash escapes in the script
+    # env sets environment variables for the SSH session
+    # 'bash -s' tells SSH to run bash and read script from stdin
+    local ssh_result
+    if ssh_result=$(printf '%b' "$upload_script" | env "${env_vars[@]}" ssh "$host" 'bash -s' 2>&1); then
+        # Parse the results returned by remote script
+        # <<< creates a here-string from the variable
+        while IFS=':' read -r status key_def error_msg; do
+            case "$status" in
+                "a"|"r") RESULTS["${key_def}:${host}"]="$status" ;;  # Success cases
+                "x") RESULTS["${key_def}:${host}"]="x" ;;              # Error case
+            esac
+        done <<< "$ssh_result"
+    else
+        echo -e "${RED}  SSH connection failed: $ssh_result${NC}"
+        # Mark all keys as error for this host
+        for key_def in "${!KEYS[@]}"; do
+            RESULTS["${key_def}:${host}"]="x"
+        done
+        return 1
+    fi
+}
+
+# Display a formatted table showing upload results
+# SECURITY NOTE: Only displays status information, never shows actual key values
+print_summary() {
+    echo -e "\n${BLUE}=== UPLOAD SUMMARY ===${NC}"
+    echo
+    
+    # Print table header row
+    printf "%-30s" "Key"  # %-30s = left-aligned, 30 characters wide
+    for host in "${HOST_LIST[@]}"; do
+        printf " %10s" "$host"  # %10s = right-aligned, 10 characters wide
+    done
+    echo
+    
+    # Print separator line
+    printf "%-30s" "$(printf '%*s' 30 '' | tr ' ' '-')"  # Create 30 dashes
+    for host in "${HOST_LIST[@]}"; do
+        printf " %10s" "----------"  # 10 dashes for each host column
+    done
+    echo
+    
+    # Print results for each key
+    for key_def in "${!KEYS[@]}"; do
+        local display_key="${KEYS[$key_def]}"  # Use env var name for display
+        printf "%-30s" "$display_key"
+        
+        for host in "${HOST_LIST[@]}"; do
+            # Get result for this key+host combination, default to "x" if not found
+            local result="${RESULTS["${key_def}:${host}"]:-x}"
+            case "$result" in
+                "a") printf " %10s" "${GREEN}added${NC}" ;;       # New key
+                "r") printf " %10s" "${YELLOW}replaced${NC}" ;;   # Existing key updated
+                "x") printf " %10s" "${RED}error${NC}" ;;       # Failed to upload
+                "missing") printf " %10s" "---" ;;               # Key not found locally
+                *) printf " %10s" "${RED}unknown${NC}" ;;        # Unexpected status
+            esac
+        done
+        echo  # New line after each key row
+    done
+    echo  # Extra blank line after table
+}
+
+# Main execution function - coordinates the entire upload process
+# SECURITY NOTE: This is the orchestrator - it doesn't handle secrets directly
+main() {
+    echo -e "${BLUE}SSH Keychain Upload Tool${NC}"
+    echo "================================"
+    echo
+    
+    # Discover hosts with ForwardAgent enabled
+    local detected_hosts
+    # mapfile reads command output into array, -t removes trailing newlines
+    # < <() is process substitution - runs get_ssh_hosts and treats output as file
+    if ! mapfile -t detected_hosts < <(get_ssh_hosts); then
+        exit 1
+    fi
+    
+    # Show hosts to user and get confirmation
+    confirm_hosts "${detected_hosts[@]}"
+    
+    # Initialize key list (currently unused but reserved for future features)
+    for key_def in "${!KEYS[@]}"; do
+        KEY_LIST+=("$key_def")
+    done
+    
+    # Upload keys to each host
+    echo -e "${BLUE}Starting key upload process...${NC}"
+    echo
+    
+    for host in "${HOST_LIST[@]}"; do
+        # || echo ensures we continue even if one host fails
+        upload_to_host "$host" || echo -e "${RED}  Failed to upload to $host${NC}"
+        echo
+    done
+    
+    # Display final results
+    print_summary
+}
+
+# Only run main if this script is executed directly (not sourced)
+# ${BASH_SOURCE[0]} is this script's name, ${0} is the executed script's name
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"  # Pass all command line arguments to main
+fi

--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -210,7 +210,7 @@ upload_to_host() {
     # Add remote keychain unlock using provided password
     upload_script+="# Unlock the remote keychain using provided password\n"
     upload_script+="if [[ -n \"\${REMOTE_KEYCHAIN_PASSWORD:-}\" ]]; then\n"
-    upload_script+="  if ! echo \"\$REMOTE_KEYCHAIN_PASSWORD\" | security unlock-keychain -p; then\n"
+    upload_script+="  if ! security unlock-keychain -p \"\$REMOTE_KEYCHAIN_PASSWORD\"; then\n"
     upload_script+="    echo 'x|keychain|unlock_failed'\n"
     upload_script+="    exit 1\n"
     upload_script+="  fi\n"

--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -18,10 +18,10 @@ NC='\033[0m' # Reset to default color
 # Format: "service_name:account_name"="ENV_VAR_NAME"
 # These define what keys to extract from macOS keychain and where to store them remotely
 declare -A KEYS=(
-    ["atlassian-mcp:atlassian-domain"]="ATLASSIAN_DOMAIN"
+    ["atlassian-mcp:domain"]="ATLASSIAN_DOMAIN"
     ["atlassian-mcp:email"]="ATLASSIAN_EMAIL"
     ["atlassian-mcp:token"]="ATLASSIAN_API_TOKEN"
-    ["bitbucket-mcp:bitbucket-username"]="ATLASSIAN_BITBUCKET_USERNAME"
+    ["bitbucket-mcp:username"]="ATLASSIAN_BITBUCKET_USERNAME"
     ["bitbucket-mcp:app-password"]="ATLASSIAN_BITBUCKET_APP_PASSWORD"
     ["github-mcp:token"]="GITHUB_PERSONAL_ACCESS_TOKEN"
     ["api_keys:OPENAI_API_KEY"]="OPENAI_API_KEY"

--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -258,12 +258,12 @@ print_summary() {
             # Get result for this key+host combination, default to "x" if not found
             local result="${RESULTS["${key_def}:${host}"]:-x}"
             case "$result" in
-                "a") printf "     %b     " "${GREEN}added${NC}" ;;       # New key (5 spaces + content + 5 spaces = 12)
-                "r") printf "   %b   " "${YELLOW}replaced${NC}" ;;   # Existing key updated (3 + content + 3 = 12)
-                "x") printf "     %b     " "${RED}error${NC}" ;;       # Failed to upload (5 + content + 5 = 12)
-                "missing") printf "     ---     " ;;               # Key not found locally (5 + 3 + 4 = 12)
-                "smoke_ok") printf "     %b      " "${GREEN}✓${NC}" ;;   # Smoke test passed (5 + content + 6 = 12)
-                *) printf "   %b   " "${RED}unknown${NC}" ;;        # Unexpected status (3 + content + 3 = 12)
+                "a") printf "     %b     " "${GREEN}added${NC}" ;;       # New key (4 spaces + content (5) + 4 spaces = 13)
+                "r") printf "   %b  " "${YELLOW}replaced${NC}" ;;   # Existing key updated (3 + content (8) + 2 = 13)
+                "x") printf "     %b    " "${RED}error${NC}" ;;       # Failed to upload (4 + content (5) + 4 = 13)
+                "missing") printf "     ---     " ;;               # Key not found locally (5 + 3 + 5 = 13)
+                "smoke_ok") printf "      %b      " "${GREEN}✓${NC}" ;;   # Smoke test passed (6 + content (1) + 6 = 13)
+                *) printf "   %b   " "${RED}unknown${NC}" ;;        # Unexpected status (3 + content (7) + 3 = 13)
             esac
         done
         echo  # New line after each key row

--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -330,12 +330,12 @@ print_summary() {
             # Get result for this key+host combination, default to "x" if not found
             local result="${RESULTS["${key_def}:${host}"]:-x}"
             case "$result" in
-                "a") printf "     %b     " "${GREEN}added${NC}" ;;       # New key (4 spaces + content (5) + 4 spaces = 13)
-                "r") printf "   %b  " "${YELLOW}replaced${NC}" ;;   # Existing key updated (3 + content (8) + 2 = 13)
-                "x") printf "     %b    " "${RED}error${NC}" ;;       # Failed to upload (4 + content (5) + 4 = 13)
-                "missing") printf "     ---     " ;;               # Key not found locally (5 + 3 + 5 = 13)
-                "smoke_ok") printf "      %b      " "${GREEN}✓${NC}" ;;   # Smoke test passed (6 + content (1) + 6 = 13)
-                *) printf "   %b   " "${RED}unknown${NC}" ;;        # Unexpected status (3 + content (7) + 3 = 13)
+                "a") printf " %b" "$(center_colored_text "${GREEN}added${NC}" 12)" ;;       # New key
+                "r") printf " %b" "$(center_colored_text "${YELLOW}replaced${NC}" 12)" ;;   # Existing key updated
+                "x") printf " %b" "$(center_colored_text "${RED}error${NC}" 12)" ;;       # Failed to upload
+                "missing") printf " %s" "$(center_text "---" 12)" ;;               # Key not found locally
+                "smoke_ok") printf " %b" "$(center_colored_text "${GREEN}✓${NC}" 12)" ;;   # Smoke test passed
+                *) printf " %b" "$(center_colored_text "${RED}unknown${NC}" 12)" ;;        # Unexpected status
             esac
         done
         echo  # New line after each key row
@@ -404,6 +404,20 @@ center_text() {
     local padding=$(( (width - text_len) / 2 ))
     local right_padding=$(( width - text_len - padding ))
     printf "%*s%s%*s" "$padding" "" "$text" "$right_padding" ""
+}
+
+# Center colored text within a specified width (handles ANSI codes)
+center_colored_text() {
+    local colored_text="$1"
+    local width="$2"
+    
+    # Remove ANSI color codes to get actual text length
+    local plain_text=$(echo -e "$colored_text" | sed 's/\x1b\[[0-9;]*m//g')
+    local text_len=${#plain_text}
+    local padding=$(( (width - text_len) / 2 ))
+    local right_padding=$(( width - text_len - padding ))
+    
+    printf "%*s%s%*s" "$padding" "" "$colored_text" "$right_padding" ""
 }
 
 # Check local key availability

--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Bash version guard - require bash 4.0 or newer for associative arrays
+if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
+    echo "Error: This script requires bash 4.0 or newer for associative array support." >&2
+    echo "Current bash version: ${BASH_VERSION}" >&2
+    echo "On macOS, install a newer bash with: brew install bash" >&2
+    echo "Then either update your PATH or use the full path: /opt/homebrew/bin/bash" >&2
+    exit 1
+fi
+
 # upload_keys.sh - Upload keychain credentials to remote SSH hosts
 # Extracts keys from local macOS keychain and uploads them to remote macOS hosts
 

--- a/scripts/upload_keys.sh
+++ b/scripts/upload_keys.sh
@@ -56,7 +56,6 @@ extract_key() {
 # Discover SSH hosts that have ForwardAgent enabled
 # Only reads SSH config, doesn't modify anything
 get_ssh_hosts() {
-    local hosts=()  # Local array (not used in current implementation)
     
     # Check if SSH config file exists
     if [[ ! -f ~/.ssh/config ]]; then
@@ -317,7 +316,7 @@ print_summary() {
     # Print separator line
     printf "%-35s" "$(printf '%*s' 35 '' | tr ' ' '-')"  # Create 35 dashes
     for host in "${HOST_LIST[@]}"; do
-        printf " %10s" "------------"  # 12 dashes for each host column
+        printf " %12s" "------------"  # 12 dashes for each host column
     done
     echo
     
@@ -401,8 +400,12 @@ center_text() {
     local text="$1"
     local width="$2"
     local text_len=${#text}
-    local padding=$(( (width - text_len) / 2 ))
-    local right_padding=$(( width - text_len - padding ))
+    local pad_total=$(( width - text_len ))
+    if (( pad_total < 0 )); then
+        pad_total=0
+    fi
+    local padding=$(( pad_total / 2 ))
+    local right_padding=$(( pad_total - padding ))
     printf "%*s%s%*s" "$padding" "" "$text" "$right_padding" ""
 }
 
@@ -414,8 +417,12 @@ center_colored_text() {
     # Remove ANSI color codes to get actual text length
     local plain_text=$(echo -e "$colored_text" | sed 's/\x1b\[[0-9;]*m//g')
     local text_len=${#plain_text}
-    local padding=$(( (width - text_len) / 2 ))
-    local right_padding=$(( width - text_len - padding ))
+    local pad_total=$(( width - text_len ))
+    if (( pad_total < 0 )); then
+        pad_total=0
+    fi
+    local padding=$(( pad_total / 2 ))
+    local right_padding=$(( pad_total - padding ))
     
     printf "%*s%s%*s" "$padding" "" "$colored_text" "$right_padding" ""
 }


### PR DESCRIPTION
`upload_keys.sh` is a bash script that uploads the values we store, for MCP servers and LLM API access, in our login keychain, to the login keychains on the remotes. This makes it so that we need not login to icloud and sync our keychains with the macs