### PR TITLE
Add minimal toolsets for built-in Agent mode and update README context window details

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ This repository provides installation guides, configuration files, scripts, and 
 ├── README.md                              # This document
 ├── TOOLS_GLOSSARY.md                      # Glossary of all available tools
 ├── copilot/
-│   └── modes/
-│       ├── QnA.chatmode.md                # Strict read-only Q&A / analysis (no mutations)
-│       ├── Plan.chatmode.md               # Remote planning & artifact curation + PR create/edit/review (no merge/branch)
-│       ├── Code-Sonnet4.chatmode.md       # Full coding, execution, PR + branch ops (Claude Sonnet 4 model)
-│       ├── Code-GPT5.chatmode.md          # Full coding, execution, PR + branch ops (GPT-5 model)
-│       ├── Review.chatmode.md             # PR & issue review feedback (comments only)
+│   ├── modes/
+│   │   ├── QnA.chatmode.md                # Strict read-only Q&A / analysis (no mutations)
+│   │   ├── Plan.chatmode.md               # Remote planning & artifact curation + PR create/edit/review (no merge/branch)
+│   │   ├── Code-Sonnet4.chatmode.md       # Full coding, execution, PR + branch ops (Claude Sonnet 4 model)
+│   │   ├── Code-GPT5.chatmode.md          # Full coding, execution, PR + branch ops (GPT-5 model)
+│   │   └── Review.chatmode.md             # PR & issue review feedback (comments only)
+│   └── toolsets/
+│       └── minimal.toolsets.jsonc         # Minimal toolsets for Agent mode
 ├── scripts/
 │   ├── mcp-github-wrapper.sh              # macOS/Linux GitHub MCP wrapper script
 │   ├── mcp-github-wrapper.ps1             # Windows GitHub MCP wrapper script
@@ -116,9 +118,26 @@ Note: Both Q and Copilot can read images. However, Q requires you to save and at
 
 
 ## Modes
+VS Code's built-in modes (Ask, Edit, Agent) differ from custom modes in their tool availability and persistence:
+
+- **Built-in modes** do not remember which tools you have enabled or disabled across sessions. Each time you restart VS Code, all MCP servers are re-enabled by default, which can consume a significant portion of Copilot's context window if you have many servers installed.
+- **Custom modes** define their own curated toolsets, allowing for more controlled and persistent configurations tailored to specific use cases.
+
+**To optimize the built-in Agent mode for better performance**, we recommend creating a minimal toolset that disables all non-essential tools. This helps prevent overwhelming the context window with too many active tools.
+1. Save (minimal.toolsets.jsonc)[copilot/toolsets/minimal.toolsets.jsonc] to your VS Code user prompts folder (see (Add Modes to VS Code)[#Add-Modes-to-VS-Code] below).
+2. From the Chat pane:
+- Select "Agent" mode
+- Open the "Configure tools..." menu
+- Unselect all tools using the "Toggle all checkboxes" button
+- Toggle "Minimal VS Code" under "User Defined Tool Sets"
+
+> Without this, installing multiple MCP servers can overwhelm the context window, leading to degraded performance.
+
+Custom modes like those provided in this repository already define their own toolsets (e.g., QnA mode includes only read-only tools, while Code modes include full editing capabilities). You can customize these toolsets further by editing the `tools` array in the respective `.chatmode.md` files.
+
 ### Modes Overview
 
-We define **four categories** of modes for different use cases, that follow a **privilege gradient:** **QnA < Review** (adds review + issue comments) **< Plan** (adds planning artifact + PR creation/edit) **< Code** (full lifecycle incl. merge & branch ops).
+We define **four categories** of custom modes for different use cases, that follow a **privilege gradient:** **QnA < Review** (adds review + issue comments) **< Plan** (adds planning artifact + PR creation/edit) **< Code** (full lifecycle incl. merge & branch ops).
 
 From these four categories, we create **five modes**. **Code-GPT5** and **Code-Sonnet4** modes provide the same toolsets with different prompts. We do this because these models respond differently to prompts and possess different strengths. For reference, see OpenAI's [GPT-5 prompting guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide) and Anthropic's [Claude 4 prompt engineering best practices](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices).
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ This repository provides guidance to configure three primary AI assistants -- Gi
 | Prompts per month                             | 300             | —               | ?            |
 | GPT-4.1 and 5 mini do not count towards limit | ✅              | n/a              | n/a          |
 | Additional usage                              | $.04/prompt     | API pricing      | ?            |
-| Context window                                | 112k tokens     | 200k tokens      | 200k tokens  |
-
+| Context window                                | 128k tokens     | 200k tokens      | 200k tokens  |
+| Context window after system prompt | 108k to 112k tokens | ? | ? |
 
 > Note: Amazon states that Q Developer Pro provides ["increased limits of agentic requests"](https://aws.amazon.com/q/developer/pricing/) compared to their free tier, but do not state those limits. As of August 27, they write, "Additional usage included until Sep 1, 2025," which suggests that will soon determine what the new limits are. They had previously stated these would be 1000; however, their equally priced [Kiro subscription](https://kiro.dev/pricing/) offers 125 "spec" requests and 225 "vibe requests" per month. For overages, they price a "spec" request four times the price of a "vibe" request. Since (125 x 4) + 225 = 725, this implies a corresponding Q usage limit of 725 monthly requests.
 

--- a/copilot/toolsets/minimal.toolsets.jsonc
+++ b/copilot/toolsets/minimal.toolsets.jsonc
@@ -1,0 +1,209 @@
+{
+	"Minimal VS Code": {
+		"tools": [
+			/////////////
+			// Changes //
+			/////////////
+			// Get diffs of changed file:
+			"changes",
+			///////////
+			// Fetch //
+			///////////
+			// Fetch the main content from a web page. You should
+			// include the URL of the page you want to fetch:
+			"fetch",
+			// Use this tool to think deeply about the user's reqeust
+			// and organize your thoughts.  This tool helps improve
+			// response quality by allowing the model to consider the
+			// request carefully, brainstorm solutions, and plan complex
+			// tasks. It's particularly useful for:
+			// 1. Exploring repository issues and brainstorming bug
+			//    fixes
+			// 2. Analyzing test resutlts and planning fixes
+			// 3. Planning complex refactoring approaches
+			// 4. Designing new features and architecture
+			// 5. Organizing debugging hypotheses
+			//    This tool logs your thought process for transparency
+			//    but doesn't execute any code or make changes.
+			///////////
+			// Todos //
+			///////////
+			// Tool for managing and tracking todo items for task
+			// planning.
+			"todos",
+			////////////
+			// Usages //
+			////////////
+			// Find references, definitions, and other usages of a
+			// symbol.
+			"usages",
+			//////////
+			// Edit //
+			//////////////////////////////////
+			// Edit files in your workspace //
+			//////////////////////////////////
+			// Create new directories in your workspace:
+			"createDirectory",
+			// Create new files:
+			"createFile",
+			// Edit files:
+			"editFiles",
+			/////////////////
+			// runCommands //
+			///////////////////////////////////
+			// Runs commands in the terminal //
+			///////////////////////////////////
+			// Get the output of a terminal command previously started
+			// with run_in_terminal:
+			"getTerminalOutput",
+			// Tool for running commands in the terminal:
+			"runInTerminal",
+			// Get the last commmand run in the active terminal:
+			"terminalLastCommand",
+			// Get the current selection in the active terminal:
+			"terminalSelection",
+			////////////
+			// Search //
+			/////////////////////////////////////////////
+			// Search and read files in your workspace //
+			/////////////////////////////////////////////
+			// == codebase ==
+			// Find relevant file chunks, symbols, and other information
+			// in your codebase:
+			"codebase",
+			// == fileSearch ==
+			// Search for files in the workspace by glob pattern. This
+			// only returns the paths of matching files. Use this tool
+			// when you know the exact filename pattern of the files
+			// you're searching for. Glob patterns match from the root
+			// of the workspace folder. Examples:
+			// - **/*.{js,ts} to match all js/ts files in the workspace
+			// - src/** to match all js files in the top-level src
+			//   folder
+			// - /foo//*.js to match all js files under any foo folder
+			//   in the workspace
+			"fileSearch",
+			// == listDirectory ==
+			// List the contents of a directory. Result with have the
+			// name of the child. If the name ends in /, it's a folder,
+			// otherwise a file.
+			"listDirectory",
+			// == readFile ==
+			// Read the contents of a file. 
+			// You must specify the line range you're interested in.
+			// Line numbers are 1-indexed. If they file contents
+			// returned are sufficient for your task, you may call this
+			// tool again to retrieve more content. Prefer reading
+			// larger ranges over doing many small reads.
+			"readFile",
+			// == textSearch ==
+			// Do a fast text search in the workspace. Use this tool
+			// when you want to search with an exact string or regex. If
+			// you are not sure what words will appear in the workspace,
+			// prefer using regex patterns with an alternation (|) or
+			// character classes to search for multiple potential words
+			// at once instead of making separate searches. For example,
+			// use 'function|method|procedure' to look for all of those
+			// words at once. Use includePattern to search within files
+			// matching a specific pattern, or in a specific file, using
+			// a relative path. Use this tool when you want to see an
+			// overview of a particular file, instead of using read_file
+			// many times to look for code within a file.
+			"textSearch",
+		],
+		"description": "Minimal tools for coding tasks",
+		"icon": "vscode"
+	},
+	"Minimal Jira": {
+		// This toolset lists two tools for each operation, with each
+		// element of the pair corresponding to a different MCP server
+		// so one can use either the Atlassian Remote MCP Server or
+		// @sooperset/mcp-atlassian
+		"tools": [
+			// == Get Issue ==
+			 "jira_get_issue",
+			 "getJiraIssue",
+			// == Create Issue ==
+            "jira_create_issue",
+			"createJiraIssue", 
+			// == Edit Issue ==
+            "jira_update_issue",
+			"editJiraIssue",
+		],
+		"description": "Minimal tools for working with Jira",
+		"icon": "issue-closed",
+	},
+	"Minimal Bitbucket": {
+		// These tools correspond to
+		// @aashari/mcp-server-atlassian-bitbucket
+		"tools": [
+			// == Commit History ==
+            "bb_get_commit_history",
+			// == Get File (at revision) ==
+			"bb_get_file",
+			// == Diffs ==
+			"bb_diff_branches",
+			"bb_diff_commits",
+			// == Pull Requests ==
+			"bb_get_pr",
+			"bb_ls_pr_comments",
+			"bb_add_pr_comment",
+			"bb_add_pr",
+			"bb_update_pr"
+		],
+		"description": "Minimal tools for working with Bitbucket",
+		"icon": "repo-forked",
+	},
+	"Minimal GitHub": {
+		"tools": [
+			// == Commit History ==
+			// List branches:
+			"list_branches",
+			// Get list of commits of a branch in a GitHub repository.
+			// Returns at least 30 results per page by default, but can
+			// return more if specified using the perPage parameter (up
+			// to 100).)
+			"list_commits",
+			// == Get File ==
+			// Get the contents of a file from a GitHub repository
+			"get_file_contents",
+			// == Pull Requests ==
+			// List pull requests:
+			"list_pull_requests",
+			// Get details of a specific pull request:
+			"get_pull_request",
+			// Get the status of as specified pull request:
+			"get_pull_request_status",
+			// Get the files changed in a specific pull request:
+			"get_pull_request_files",
+			// Get the diff of a pull request:
+			"get_pull_request_diff",
+			// Get comments for a specific pull request:
+			"list_pull_request_comments",
+			// Get reviews for a specific pull request:
+			"list_pull_request_reviews",
+			// Update an existing pull request:
+			"update_pull_request",
+			// Create and submit a review for a pull request:
+			"create_and_submit_pull_request_review",
+			// Create a pending review for a pull request:
+			"create_pending_pull_request_review",
+			// Submit the requester's pending pull request review:
+			"submit_pending_pull_request_review",
+			// Add a review comment to the requester's latest pending
+			// pull request review:
+			"add_comment_to_pending_review",
+			// == Issues ==
+			// Get details of a specific issue in a GitHub repository:
+			"get_issue",
+			// Get comments for a specific issue in a GitHub repository:
+			"get_issue_comments",
+			// Add a comment to a specific issue in a GitHub repository:
+			"add_issue_comment",
+			// Update an existing issue in a GitHub repository:
+			"update_issue"
+		],
+		"description": "Minimal tools for working with GitHub",
+		"icon": "github"
+	}
+}


### PR DESCRIPTION
Introduce minimal toolsets for the built-in Agent mode to enhance performance by limiting active tools. Update README to reflect changes in context window specifications.

Previously, I had just not been using Agent mode -- but I had been thinking about what if I wanted the "Code" mode toolsets without the additional prompt instructions. This resolves that problem.